### PR TITLE
Curity 3.0 upgrade

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ This project provides an opens source Twitter Authenticator plug-in for the Curi
 System Requirements
 ~~~~~~~~~~~~~~~~~~~
 
-* Curity Identity Server 2.4.0 and `its system requirements <https://developer.curity.io/docs/latest/system-admin-guide/system-requirements.html>`_
+* Curity Identity Server 2.4.0+ and `its system requirements <https://developer.curity.io/docs/latest/system-admin-guide/system-requirements.html>`_
 
 Requirements for Building from Source
 """""""""""""""""""""""""""""""""""""
@@ -22,10 +22,15 @@ Compiling the Plug-in from Source
 
 The source is very easy to compile. To do so from a shell, issue this command: ``mvn package``.
 
+This will place the package, along with the relevant dependencies, in the ``target/libs`` directory.
+
 Installation
 ~~~~~~~~~~~~
 
-To install this plug-in, either download a binary version available from the `releases section of this project's GitHub repository <https://github.com/curityio/twitter-authenticator/releases>`_ or compile it from source (as described above). If you compiled the plug-in from source, the package will be placed in the ``target`` subdirectory. The resulting JAR file or the one downloaded from GitHub needs to placed in the directory ``${IDSVR_HOME}/usr/share/plugins/twitter``. (The name of the last directory, ``twitter``, which is the plug-in group, is arbitrary and can be anything.) After doing so, the plug-in will become available as soon as the node is restarted.
+This plug-in can be either downloaded from the `releases section of this project's GitHub repository <https://github.com/curityio/twitter-authenticator/releases>`_ or compiled from source (as described above).
+
+In either case, to install the plugin, copy the plug-in jar and its dependencies to the ``${IDSVR_HOME}/usr/share/plugins/twitter`` directory (the name of the last directory, ``twitter``, which is the plug-in group, is arbitrary and can be anything).
+After doing so, the plug-in will become available as soon as the node is restarted.
 
 .. note::
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <libraries.directory>${project.build.directory}/libs</libraries.directory>
     </properties>
 
     <build>
@@ -24,6 +25,32 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.3.1</version>
+                    <configuration>
+                        <outputDirectory>${libraries.directory}</outputDirectory>
+                    </configuration>
+                </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${libraries.directory}</outputDirectory>
+                            <excludeArtifactIds>identityserver.sdk,slf4j-api</excludeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.curity.identityserver.plugin</groupId>
     <artifactId>identityserver.plugins.authenticators.twitter</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <name>Twitter Authenticator</name>
 
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>se.curity.identityserver</groupId>
             <artifactId>identityserver.sdk</artifactId>
-            <version>2.4.0</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
I improved a little bit the build by putting the jar and the dependencies that need to be deployed into the `target/libs` folder.

Updated the README accordingly.

Upgraded to Curity 3.0. No code changes required.