### PR TITLE
Improved error reporting when Twitter service fails.

### DIFF
--- a/src/main/java/io/curity/identityserver/plugin/twitter/authentication/TwitterAuthenticatorRequestHandler.java
+++ b/src/main/java/io/curity/identityserver/plugin/twitter/authentication/TwitterAuthenticatorRequestHandler.java
@@ -66,20 +66,21 @@ public class TwitterAuthenticatorRequestHandler implements AuthenticatorRequestH
                 .apiSecret(_config.getClientSecret())
                 .callback(createRedirectUri())
                 .build(TwitterApi.instance());
-        String authorizationEndpoint = "";
-        
+
+
+        final OAuth1RequestToken requestToken;
         try
         {
-            final OAuth1RequestToken requestToken = service.getRequestToken();
-            authorizationEndpoint = service.getAuthorizationUrl(requestToken);
-            _config.getSessionManager().put(Attribute.of(OAUTH_TOKEN, requestToken.getToken()));
-            _config.getSessionManager().put(Attribute.of(OAUTH_TOKEN_SECRET, requestToken.getTokenSecret()));
-
+            requestToken = service.getRequestToken();
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            throw _exceptionFactory.externalServiceException("Error authenticating with Twitter: " + e);
         }
+
+        String authorizationEndpoint = service.getAuthorizationUrl(requestToken);
+        _config.getSessionManager().put(Attribute.of(OAUTH_TOKEN, requestToken.getToken()));
+        _config.getSessionManager().put(Attribute.of(OAUTH_TOKEN_SECRET, requestToken.getTokenSecret()));
 
         _logger.debug("Redirecting to {}", authorizationEndpoint);
 


### PR DESCRIPTION
On error getting a token, the plugin was just printing the stacktrace and trying to continue redirecting the client to the empty URL which would then fail in the Curity server... this made it hard to find out why the plugin was not working.

This PR makes the error obvious by throwing a `ExternalServiceException` which reports exactly what the problem is on the Twitter side.

The user will still see a 500 without further information. But that's a Curity issue, not this plugins'.